### PR TITLE
Add nodejs as build dependency in documentation

### DIFF
--- a/DOCS/INSTALL.md
+++ b/DOCS/INSTALL.md
@@ -12,6 +12,7 @@ To use this repository, you will need:
 * [Packer](https://www.packer.io) (1.4.2+)
 * `git` (2.21+)
 * `make`
+* `node`
 * Access to a `bash` shell.
 
 ## Step by step instructions


### PR DESCRIPTION
Node is used when writing the configuration files