### PR TITLE
Unset cookie so that varnish can cache requests

### DIFF
--- a/templates/varnish.vcl.mustache
+++ b/templates/varnish.vcl.mustache
@@ -22,6 +22,8 @@ sub vcl_recv {
         }
         return (lookup);
     }
+    
+    unset req.http.cookie;
 
     # Routing request to backend based on X-Carto-Service header from nginx
     if (req.http.X-Carto-Service == "sqlapi") {


### PR DESCRIPTION
Varnish doesn't cache requests with the cookie because each one has another cookie